### PR TITLE
Use new object generate API as the old one is deprecated.

### DIFF
--- a/src/daos_vol.c
+++ b/src/daos_vol.c
@@ -1591,7 +1591,7 @@ H5_daos_pool_connect_prep_cb(tse_task_t *task, void H5VL_DAOS_UNUSED *args)
     memset(connect_args, 0, sizeof(*connect_args));
     connect_args->poh = udata->poh;
     connect_args->grp = udata->grp;
-#if !defined(DAOS_API_VERSION_MAJOR) || (defined(DAOS_API_VERSION_MAJOR) && (DAOS_API_VERSION_MAJOR < 1))
+#if !defined(DAOS_API_VERSION_MAJOR) || DAOS_API_VERSION_MAJOR < 1
     connect_args->svc = udata->svc;
 #endif
     connect_args->flags = udata->flags;
@@ -2752,7 +2752,12 @@ H5_daos_oid_encode(daos_obj_id_t *oid, uint64_t oidx, H5I_type_t obj_type,
         object_class = (obj_type == H5I_DATASET) ? OC_SX : OC_S1;
 
     /* Generate oid */
-    H5_daos_obj_generate_id(oid, object_feats, object_class);
+#if !defined(DAOS_API_VERSION_MAJOR) || DAOS_API_VERSION_MAJOR < 1
+    daos_obj_generate_id(oid, object_feats, object_class);
+#else
+    if (daos_obj_generate_oid(file->coh, oid, object_feats, object_class, 0, 0) != 0)
+        D_GOTO_ERROR(H5E_VOL, H5E_CANTSET, FAIL, "Can't set object class");
+#endif
 
 done:
     D_FUNC_LEAVE;

--- a/src/daos_vol.h
+++ b/src/daos_vol.h
@@ -46,8 +46,6 @@ typedef d_sg_list_t daos_sg_list_t;
 # define daos_iov_set d_iov_set
 # define DAOS_OF_AKEY_HASHED 0
 # define DAOS_OF_DKEY_HASHED 0
-# define H5_daos_obj_generate_id(oid, ofeats, cid) \
-    daos_obj_generate_id(oid, ofeats, cid, 0)
 
 /* For HDF5 compatibility */
 #ifndef H5E_ID

--- a/src/daos_vol_file.c
+++ b/src/daos_vol_file.c
@@ -857,12 +857,6 @@ H5_daos_file_create(const char *name, unsigned flags, hid_t fcpl_id,
     if(H5_daos_fill_enc_plist_cache(file, fapl_id) < 0)
         D_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "failed to fill encoded property list buffer cache");
 
-    /* Generate oid for global metadata object */
-    if(H5_daos_oid_encode(&file->glob_md_oid, H5_DAOS_OIDX_GMD, H5I_GROUP,
-            fcpl_id == H5P_FILE_CREATE_DEFAULT ? H5P_DEFAULT : fcpl_id,
-            H5_DAOS_OBJ_CLASS_NAME, file) < 0)
-        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode global metadata object ID");
-
     /* Start H5 operation */
     if(NULL == (int_req = H5_daos_req_create(file, "file create", NULL, NULL, NULL, H5I_INVALID_HID)))
         D_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't create DAOS request");
@@ -886,6 +880,15 @@ H5_daos_file_create(const char *name, unsigned flags, hid_t fcpl_id,
      */
     if((file->num_procs > 1) && (H5_daos_file_handles_bcast(file, int_req, &first_task, &dep_task) < 0))
         D_GOTO_ERROR(H5E_VOL, H5E_CANTSET, NULL, "can't broadcast DAOS container/pool handles");
+
+    /* Block until operation completes */
+    if(H5_daos_task_wait(&(first_task), &(dep_task)) < 0)
+        D_DONE_ERROR(H5E_VOL, H5E_CANTINIT, NULL, "can't progress scheduler");
+
+    if(H5_daos_oid_encode(&file->glob_md_oid, H5_DAOS_OIDX_GMD, H5I_GROUP,
+            fcpl_id == H5P_FILE_CREATE_DEFAULT ? H5P_DEFAULT : fcpl_id,
+            H5_DAOS_OBJ_CLASS_NAME, file) < 0)
+        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode global metadata object ID");
 
     /* Open global metadata object */
     if(H5_daos_obj_open(file, int_req, &file->glob_md_oid, DAOS_OO_RW, &file->glob_md_oh, "global metadata object open", &first_task, &dep_task) < 0)
@@ -1580,18 +1583,6 @@ H5_daos_file_open(const char *name, unsigned flags, hid_t fapl_id,
     if(H5_daos_fill_enc_plist_cache(file, fapl_id) < 0)
         D_GOTO_ERROR(H5E_FILE, H5E_CANTINIT, NULL, "failed to fill encoded property list buffer cache");
 
-    /* Generate oid for global metadata object */
-    if(H5_daos_oid_encode(&file->glob_md_oid, H5_DAOS_OIDX_GMD, H5I_GROUP,
-            fapl_id == H5P_FILE_ACCESS_DEFAULT ? H5P_DEFAULT : fapl_id,
-            H5_DAOS_ROOT_OPEN_OCLASS_NAME, file) < 0)
-        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode global metadata object ID");
-
-    /* Generate root group oid */
-    if(H5_daos_oid_encode(&root_grp_oid, H5_DAOS_OIDX_ROOT, H5I_GROUP,
-            fapl_id == H5P_FILE_ACCESS_DEFAULT ? H5P_DEFAULT : fapl_id,
-            H5_DAOS_ROOT_OPEN_OCLASS_NAME, file) < 0)
-        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode root group object ID");
-
     /* Start H5 operation */
     if(NULL == (int_req = H5_daos_req_create(file, "file open", NULL, NULL, NULL, H5I_INVALID_HID)))
         D_GOTO_ERROR(H5E_FILE, H5E_CANTALLOC, NULL, "can't create DAOS request");
@@ -1607,6 +1598,22 @@ H5_daos_file_open(const char *name, unsigned flags, hid_t fapl_id,
      */
     if((file->num_procs > 1) && (H5_daos_file_handles_bcast(file, int_req, &first_task, &dep_task) < 0))
         D_GOTO_ERROR(H5E_FILE, H5E_CANTSET, NULL, "can't broadcast DAOS container/pool handles");
+
+    /* Block until operation completes */
+    if(H5_daos_task_wait(&(first_task), &(dep_task)) < 0)
+        D_DONE_ERROR(H5E_VOL, H5E_CANTINIT, NULL, "can't progress scheduler");
+
+    /* Generate oid for global metadata object */
+    if(H5_daos_oid_encode(&file->glob_md_oid, H5_DAOS_OIDX_GMD, H5I_GROUP,
+            fapl_id == H5P_FILE_ACCESS_DEFAULT ? H5P_DEFAULT : fapl_id,
+            H5_DAOS_ROOT_OPEN_OCLASS_NAME, file) < 0)
+        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode global metadata object ID");
+
+    /* Generate root group oid */
+    if(H5_daos_oid_encode(&root_grp_oid, H5_DAOS_OIDX_ROOT, H5I_GROUP,
+            fapl_id == H5P_FILE_ACCESS_DEFAULT ? H5P_DEFAULT : fapl_id,
+            H5_DAOS_ROOT_OPEN_OCLASS_NAME, file) < 0)
+        D_GOTO_ERROR(H5E_FILE, H5E_CANTENCODE, NULL, "can't encode root group object ID");
 
     /* Open global metadata object */
     if(H5_daos_obj_open(file, int_req, &file->glob_md_oid, flags & H5F_ACC_RDWR ? DAOS_COO_RW : DAOS_COO_RO, &file->glob_md_oh, "global metadata object open", &first_task, &dep_task) < 0)


### PR DESCRIPTION
as of daos:
https://github.com/daos-stack/daos/commit/684b9a86fc185aee1d1fefbbca156fbf8b3024da

The new API requires a container handle, so add a wait for the container to be open
before generating the APIs for the glob metadata and root objects.