### PR TITLE
Use new object generate API as the old one is deprecated.

### DIFF
--- a/src/daos_vol.h
+++ b/src/daos_vol.h
@@ -46,8 +46,6 @@ typedef d_sg_list_t daos_sg_list_t;
 # define daos_iov_set d_iov_set
 # define DAOS_OF_AKEY_HASHED 0
 # define DAOS_OF_DKEY_HASHED 0
-# define H5_daos_obj_generate_id(oid, ofeats, cid) \
-    daos_obj_generate_id(oid, ofeats, cid, 0)
 
 /* For HDF5 compatibility */
 #ifndef H5E_ID
@@ -1111,8 +1109,8 @@ H5VL_DAOS_PRIVATE herr_t H5_daos_oidx_generate(uint64_t *oidx,
 H5VL_DAOS_PRIVATE herr_t H5_daos_oid_encode(daos_obj_id_t *oid, uint64_t oidx,
     H5I_type_t obj_type, hid_t crt_plist_id, const char *oclass_prop_name,
     H5_daos_file_t *file);
-H5VL_DAOS_PRIVATE herr_t H5_daos_oid_generate(daos_obj_id_t *oid,
-    H5I_type_t obj_type, hid_t crt_plist_id, H5_daos_file_t *file,
+H5VL_DAOS_PRIVATE herr_t H5_daos_oid_generate(daos_obj_id_t *oid, hbool_t oidx_set, uint64_t oidx,
+    H5I_type_t obj_type, hid_t crt_plist_id, const char *oclass_prop_name, H5_daos_file_t *file,
     hbool_t collective, H5_daos_req_t *req, tse_task_t **first_task, tse_task_t **dep_task);
 H5VL_DAOS_PRIVATE herr_t H5_daos_oid_to_token(daos_obj_id_t oid, H5O_token_t *obj_token);
 H5VL_DAOS_PRIVATE herr_t H5_daos_token_to_oid(const H5O_token_t *obj_token, daos_obj_id_t *oid);
@@ -1218,8 +1216,8 @@ H5VL_DAOS_PRIVATE H5_daos_obj_t *H5_daos_group_traverse(H5_daos_item_t *item,
 H5VL_DAOS_PRIVATE void *H5_daos_group_create_helper(H5_daos_file_t *file, hbool_t is_root,
     hid_t gcpl_id, hid_t gapl_id, H5_daos_group_t *parent_grp, const char *name, size_t name_len,
     hbool_t collective, H5_daos_req_t *req, tse_task_t **first_task, tse_task_t **dep_task);
-H5VL_DAOS_PRIVATE H5_daos_group_t *H5_daos_group_open_helper(
-    H5_daos_file_t *file, hid_t gapl_id, hbool_t collective, H5_daos_req_t *req,
+H5VL_DAOS_PRIVATE int H5_daos_group_open_helper(
+    H5_daos_file_t *file, H5_daos_group_t *grp, hid_t gapl_id, hbool_t collective, H5_daos_req_t *req,
     tse_task_t **first_task, tse_task_t **dep_task);
 H5VL_DAOS_PRIVATE H5_daos_group_t *H5_daos_group_open_int(H5_daos_item_t *item,
     const H5VL_loc_params_t *loc_params, const char *name, hid_t gapl_id,

--- a/src/daos_vol_dset.c
+++ b/src/daos_vol_dset.c
@@ -742,8 +742,8 @@ H5_daos_dataset_create_helper(H5_daos_file_t *file, hid_t type_id, hid_t space_i
     } /* end if */
 
     /* Generate dataset oid */
-    if(H5_daos_oid_generate(&dset->obj.oid, H5I_DATASET,
-            (default_dcpl ? H5P_DEFAULT : dset->dcpl_id),
+    if(H5_daos_oid_generate(&dset->obj.oid, FALSE, 0, H5I_DATASET,
+            (default_dcpl ? H5P_DEFAULT : dset->dcpl_id), H5_DAOS_OBJ_CLASS_NAME,
             file, collective, req, first_task, dep_task) < 0)
         D_GOTO_ERROR(H5E_DATASET, H5E_CANTINIT, NULL, "can't generate object id");
 

--- a/src/daos_vol_map.c
+++ b/src/daos_vol_map.c
@@ -260,8 +260,8 @@ H5_daos_map_create(void *_item,
     } /* end if */
 
     /* Generate map oid */
-    if(H5_daos_oid_generate(&map->obj.oid, H5I_MAP,
-            (default_mcpl ? H5P_DEFAULT : mcpl_id),
+    if(H5_daos_oid_generate(&map->obj.oid, FALSE, 0, H5I_MAP,
+            (default_mcpl ? H5P_DEFAULT : mcpl_id), H5_DAOS_OBJ_CLASS_NAME,
             item->file, collective, int_req, &first_task, &dep_task) < 0)
         D_GOTO_ERROR(H5E_MAP, H5E_CANTINIT, NULL, "can't generate object id");
 

--- a/src/daos_vol_type.c
+++ b/src/daos_vol_type.c
@@ -700,8 +700,8 @@ H5_daos_datatype_commit_helper(H5_daos_file_t *file, hid_t type_id,
     dtype->tapl_id = H5P_DATATYPE_ACCESS_DEFAULT;
 
     /* Generate datatype oid */
-    if(H5_daos_oid_generate(&dtype->obj.oid, H5I_DATATYPE,
-            (default_tcpl ? H5P_DEFAULT : tcpl_id),
+    if(H5_daos_oid_generate(&dtype->obj.oid, FALSE, 0, H5I_DATATYPE,
+            (default_tcpl ? H5P_DEFAULT : tcpl_id), H5_DAOS_OBJ_CLASS_NAME,
             file, collective, req, first_task, dep_task) < 0)
         D_GOTO_ERROR(H5E_DATATYPE, H5E_CANTINIT, NULL, "can't generate object id");
 

--- a/test/daos_vol/h5daos_test_oclass.c
+++ b/test/daos_vol/h5daos_test_oclass.c
@@ -116,7 +116,7 @@ test_oclass(hid_t fcpl_id, hid_t fapl_id, const char *exp_root_oclass,
     /* Create custom group */
     if((plist_id = H5Pcreate(H5P_GROUP_CREATE)) < 0)
         TEST_ERROR
-    if(H5daos_set_object_class(plist_id, "SX") < 0)
+    if(H5daos_set_object_class(plist_id, "S2") < 0)
         TEST_ERROR
     if((obj_id = H5Gcreate2(file_id, MOD_GROUP_NAME, H5P_DEFAULT, plist_id, H5P_DEFAULT)) < 0)
         TEST_ERROR
@@ -127,7 +127,7 @@ test_oclass(hid_t fcpl_id, hid_t fapl_id, const char *exp_root_oclass,
     /* Check group's object class */
     if((plist_id = H5Gget_create_plist(obj_id)) < 0)
         TEST_ERROR
-    if(0 != check_plist_oclass(plist_id, "SX")) {
+    if(0 != check_plist_oclass(plist_id, "S2")) {
         H5_FAILED() AT()
         printf("object class check failed for custom group\n");
         goto error;
@@ -147,11 +147,14 @@ test_oclass(hid_t fcpl_id, hid_t fapl_id, const char *exp_root_oclass,
     /* Check dataset's object class */
     if((plist_id = H5Dget_create_plist(obj_id)) < 0)
         TEST_ERROR
+    /** SX is translated to the largest number of targets available on a system. skip this for now */
+#if 0
     if(0 != check_plist_oclass(plist_id, exp_dset_oclass)) {
         H5_FAILED() AT()
         printf("object class check failed for default dataset\n");
         goto error;
     } /* end if */
+#endif
     if(H5Pclose(plist_id) < 0)
         TEST_ERROR
     plist_id = -1;
@@ -241,7 +244,7 @@ test_oclass(hid_t fcpl_id, hid_t fapl_id, const char *exp_root_oclass,
             TEST_ERROR
         if((plist_id = H5Gget_create_plist(obj_id)) < 0)
             TEST_ERROR
-        if(0 != check_plist_oclass(plist_id, "SX")) {
+        if(0 != check_plist_oclass(plist_id, "S2")) {
             H5_FAILED() AT()
             printf("object class check failed for custom group after %s reopen", i ? "file" : "object");
             goto error;
@@ -258,11 +261,14 @@ test_oclass(hid_t fcpl_id, hid_t fapl_id, const char *exp_root_oclass,
             TEST_ERROR
         if((plist_id = H5Dget_create_plist(obj_id)) < 0)
             TEST_ERROR
+        /** SX is translated to the largest number of targets available on a system. skip this for now */
+#if 0
         if(0 != check_plist_oclass(plist_id, exp_dset_oclass)) {
             H5_FAILED() AT()
             printf("object class check failed for default dataset after %s reopen", i ? "file" : "object");
             goto error;
         } /* end if */
+#endif
         if(H5Pclose(plist_id) < 0)
             TEST_ERROR
         plist_id = -1;


### PR DESCRIPTION
as of daos:
daos-stack/daos@684b9a8

The new API requires a container handle. Change the oid generation into
an async task to be executed after the container open. this required
some internal changes to some functions to make it happen async as
previously it was assumed sync.

Some tests in the oclass test need to be disabled, because SX is now dynamic.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>