### PR TITLE
Avoid copying iteration udata in name order iteration fallback path

### DIFF
--- a/src/daos_vol_link.c
+++ b/src/daos_vol_link.c
@@ -5426,6 +5426,14 @@ H5_daos_link_ibco_end_task(tse_task_t *task)
         if(udata->iter_data->op_ret_p)
             *udata->iter_data->op_ret_p = udata->iter_data->op_ret;
 
+        /* Free hash table */
+        udata->iter_data->u.link_iter_data.recursive_link_path = DV_free(udata->iter_data->u.link_iter_data.recursive_link_path);
+
+        if(udata->iter_data->u.link_iter_data.visited_link_table) {
+            dv_hash_table_free(udata->iter_data->u.link_iter_data.visited_link_table);
+            udata->iter_data->u.link_iter_data.visited_link_table = NULL;
+        } /* end if */
+
         /* Free iter data */
         udata->iter_data = DV_free(udata->iter_data);
     } /* end if */
@@ -6059,8 +6067,6 @@ H5_daos_link_ibco_helper(H5_daos_group_t *target_grp,
         if(NULL == (ibco_udata->iter_data = (H5_daos_iter_data_t *)DV_malloc(sizeof(H5_daos_iter_data_t))))
             D_GOTO_ERROR(H5E_RESOURCE, H5E_CANTALLOC, -H5_DAOS_ALLOC_ERROR, "can't allocate iteration data");
         memcpy(ibco_udata->iter_data, iter_data, sizeof(*iter_data));
-        if(H5Iinc_ref(ibco_udata->iter_data->iter_root_obj) < 0)
-            D_GOTO_ERROR(H5E_LINK, H5E_CANTINC, -H5_DAOS_SETUP_ERROR, "can't increment reference count on iteration base object");
     } /* end if */
     else
         ibco_udata->iter_data = iter_data;

--- a/src/daos_vol_link.c
+++ b/src/daos_vol_link.c
@@ -5928,7 +5928,7 @@ H5_daos_link_ibco_task(tse_task_t *task)
              * index_type field in iter_data since the internal functions for
              * iteration by name order don't check this field */
             if(0 != (ret = H5_daos_list_key_init(udata->iter_data, &udata->target_grp->obj,
-                    NULL, DAOS_OPC_OBJ_LIST_DKEY, H5_daos_link_iterate_list_comp_cb, TRUE,
+                    NULL, DAOS_OPC_OBJ_LIST_DKEY, H5_daos_link_iterate_list_comp_cb, FALSE,
                     H5_DAOS_ITER_LEN, H5_DAOS_ITER_SIZE_INIT, &first_task, &dep_task)))
                 D_GOTO_ERROR(H5E_LINK, H5E_CANTINIT, ret, "can't fall back to iteration by name order: %s", H5_daos_err_to_string(ret));
 


### PR DESCRIPTION
@fortnern You were right previously about avoiding the free here introducing a new memory leak. Turns out I didn't see those leaks because I had the related visiting and iteration tests disabled due to the issue that crashes DAOS. The real fix here is to avoid making a copy of the iteration udata when iteration by creation order falls back to iteration by name order. This way, the pointers are correctly shared and freed only by the creation order iteration path, rather than both the name order and creation order paths. The previous incorrect commit is reverted here.