### PR TITLE
DER_EVICTED has been renamed DER_EXCLUDED

### DIFF
--- a/src/util/daos_vol_err.c
+++ b/src/util/daos_vol_err.c
@@ -171,8 +171,13 @@ H5_daos_err_to_string(int ret)
             return "service group not attached (DER_NOTATTACH)";
         case -DER_MISMATCH:
             return "version mismatch (DER_MISMATCH)";
+#ifdef DER_EVICTED
         case -DER_EVICTED:
             return "rank has been evicted (DER_EVICTED)";
+#else
+        case -DER_EXCLUDED:
+            return "rank has been excluded (DER_EXCLUDED)";
+#endif
         case -DER_NOREPLY:
             return "user-provided RPC handler didn't send reply back (DER_NOREPLY)";
         case -DER_DOS:


### PR DESCRIPTION
In https://github.com/daos-stack/daos/commit/fe6c2f2d33502f4410dc332207e0f23679e5d26d `DER_EVICTED` was renamed
`DER_EXCLUDED`.  This commit makes the corresponding change.

But it allows either `DER_EXCLUDED` and `DER_EVICTED` so that users can
continue to use current and previous versions of DAOS.