### PR TITLE
chore: make output file name consistent.

### DIFF
--- a/test/daos_vol/h5daos_test_map_parallel.c
+++ b/test/daos_vol/h5daos_test_map_parallel.c
@@ -12,7 +12,7 @@
 
 #include "daos_vol.h"
 
-#define PARALLEL_FILENAME "h5_daos_test_map_parallel.h5"
+#define PARALLEL_FILENAME "h5daos_test_map_parallel.h5"
 
 /*
  * Currently unsupported functionality


### PR DESCRIPTION
Cf. `h5daos_test_map.c`.